### PR TITLE
Update README requires ganache global install for WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repo holds all the genesis contracts on Core blockchain, which are part of 
 
 
 ## Prepare
-If using WSL2, install ganache globally:
+Install ganache globally:
 ```shell script
 npm install -g ganache
 ```
@@ -29,8 +29,6 @@ Install dependency:
 ```shell script
 npm install
 ```
-
-
 
 ## Run Tests
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This repo holds all the genesis contracts on Core blockchain, which are part of 
 
 
 ## Prepare
+If using WSL2, install ganache globally:
+```shell script
+npm install -g ganache
+```
 
 Install dependency:
 ```shell script


### PR DESCRIPTION
While using the core contracts repo I noticed a dependency was missing/unmentioned when trying to run the tests using WSL2.

I needed to install ganache globally via NPM or I get the following error when attempting to run:

`brownie test -v --stateful false.`

The following error occurred 

`INTERNALERROR> FileNotFoundError: [Errno 2] No such file or directory: 'ganache-cli'`

I have updated the README to suggest installing ganache globally if the user is working with WSL2. This solves the issue and causes the tests to run correctly. 